### PR TITLE
[버그 수정] 프로필 수정 이후 Jwt 토큰 에러 발생

### DIFF
--- a/src/main/java/com/dodream/common/exception/BaseException.java
+++ b/src/main/java/com/dodream/common/exception/BaseException.java
@@ -13,6 +13,7 @@ public class BaseException extends RuntimeException {
     public static final BaseException BOOK_CATEGORY_NOT_FOUND = new BaseException(ErrorCode.BOOK_CATEGORY_NOT_FOUND);
     public static final BaseException BOOK_SEARCH_NOT_FOUND = new BaseException(ErrorCode.BOOK_SEARCH_NOT_FOUND);
     public static final BaseException INTERNAL_SERVER_ERROR = new BaseException(ErrorCode.INTERNAL_SERVER_ERROR);
+    public static final BaseException INVALID_TOKEN = new BaseException(ErrorCode.INVALID_TOKEN);
 
     private final ErrorCode errorCode;
 

--- a/src/main/java/com/dodream/common/exception/ErrorCode.java
+++ b/src/main/java/com/dodream/common/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
 
     /* 400 */
     VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "VALIDATION_FAILED", "입력값 유효성 검사에 실패했습니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
 
     /* 404 */
     BOOK_CATEGORY_ERROR(HttpStatus.NOT_FOUND, "BOOK_CATEGORY_ERROR", "해당 카테고리는 존재하지 않습니다"),

--- a/src/main/java/com/dodream/security/JwtProvider.java
+++ b/src/main/java/com/dodream/security/JwtProvider.java
@@ -1,5 +1,7 @@
 package com.dodream.security;
 
+import com.dodream.common.exception.BaseException;
+import com.dodream.common.exception.ErrorCode;
 import com.dodream.user.entity.User;
 import com.dodream.user.repository.UserRepository;
 import io.jsonwebtoken.Claims;
@@ -47,8 +49,7 @@ public class JwtProvider {
             .issuer(jwtProperties.getIssuer()) // 발행자 정보 설정
             .issuedAt(new Date()) // 발행일시 설정
             .expiration(expiredDate) // 만료 시간 설정
-            .subject(user.getUsername()) // 토큰의 주제(Subject) 설정 _ 사용자 이메일
-            .claim("username", user.getUsername())
+            .subject(String.valueOf(user.getId())) // 토큰의 주제(Subject) 설정 - 사용자 id
             .signWith(getSecretKey(), Jwts.SIG.HS256) // 비밀키와 해시 알고리즘 사용하여 토큰 설명값 설정
             .compact(); // 토큰 정보들을 최종적으로 압축해서 문자열로 반환
         log.info("[makeToken] 완성된 토큰 : {}", token);
@@ -71,10 +72,8 @@ public class JwtProvider {
             log.info("토큰 검증 통과");
             return true;
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new BaseException(ErrorCode.INVALID_TOKEN);
         }
-        log.info("토큰 검증 실패");
-        return false;
     }
 
     // 토큰에서 정보(Claim) 추출 메소드
@@ -89,16 +88,16 @@ public class JwtProvider {
     // 토큰에서 인증 정보 반환하는 메소드
     public Authentication getAuthenticationByToken(String token) {
         log.info("[getAuthenticationByToken] 토큰 인증 정보 조회");
-        String username = getUsernameByToken(token);
-        User user = userRepository.findByUsername(username).get();
+        String userId = getUserIdByToken(token);
+        User user = userRepository.findById(Long.valueOf(userId)).get();
         return new UsernamePasswordAuthenticationToken(
             user, token, user.getAuthorities()
         );
     }
 
     // 토큰에서 사용자 이름만 추출하는 메소드
-    public String getUsernameByToken(String token) {
-        log.info("[getUsernameByToken] 토큰 기반 회원 식별 정보 추출");
+    public String getUserIdByToken(String token) {
+        log.info("[getUserIdByToken] 토큰 기반 회원 식별 정보 추출");
         Claims claims = getClaims(token);
         return claims.get("sub", String.class);
     }

--- a/src/test/java/com/dodream/security/JwtProviderTest.java
+++ b/src/test/java/com/dodream/security/JwtProviderTest.java
@@ -90,12 +90,12 @@ class JwtProviderTest {
         // given (사전 준비)
         String username = "codesche";
         String token = JwtFactory.builder()
-                    .claims(Map.of("username", username))
+                    .claims(Map.of("codesche", username))
                     .build()
                     .createToken(jwtProperties);
 
         // when (테스트 진행할 행위)
-        String usernameByToken = jwtProvider.getUsernameByToken(token);
+        String usernameByToken = jwtProvider.getUserIdByToken(token);
 
         // then (행위에 대한 결과 검증)
         assertThat(usernameByToken).isEqualTo(username);


### PR DESCRIPTION
# 요약 

마이페이지에서 프로필 수정한 이후에 토큰을 사용하지 못하는 경우가 발생
(기존에 설정된 username이 고유값이 아니어서 발생)

# 연관이슈
#64

closes #64

# Pull Request 체크리스트
- [x] 🔥 고유값인 id로 수정

## TODO
- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?

### 참고자료

